### PR TITLE
fix: change query param merging logic

### DIFF
--- a/js/src/forum/components/UserAutocompleteDropdown.tsx
+++ b/js/src/forum/components/UserAutocompleteDropdown.tsx
@@ -164,7 +164,7 @@ export default class UserAutocompleteDropdown extends Component<IAttrs, IState> 
     }
 
     if (old !== params.author) {
-      m.route.set(app.route(app.current.get('routeName'), { ...m.route.param(), ...params }));
+      m.route.set(app.route(app.current.get('routeName'), { ...params }));
     }
   }
 

--- a/src/Middleware/AddUserFilter.php
+++ b/src/Middleware/AddUserFilter.php
@@ -37,6 +37,10 @@ class AddUserFilter implements MiddlewareInterface
                 'author' => $author,
             ]);
 
+            if (isset($params['q']) && $params['q'] !== '') {
+                $params['q'] = trim($params['q']) . ' author:' . $author;
+            }
+
             $request = $request->withQueryParams($params);
 
             return $handler->handle($request);

--- a/src/Middleware/AddUserFilter.php
+++ b/src/Middleware/AddUserFilter.php
@@ -33,11 +33,11 @@ class AddUserFilter implements MiddlewareInterface
         $params = $request->getQueryParams();
 
         if ($author = Arr::pull($params, 'author')) {
-            $request = $request->withQueryParams(
-                array_merge($params, [
-                    'filter' => ['author' => $author]
-                ])
-            );
+            $params['filter'] = array_merge($params['filter'] ?? [], [
+                'author' => $author,
+            ]);
+
+            $request = $request->withQueryParams($params);
 
             return $handler->handle($request);
         }

--- a/src/Middleware/AddUserFilter.php
+++ b/src/Middleware/AddUserFilter.php
@@ -37,7 +37,7 @@ class AddUserFilter implements MiddlewareInterface
                 'author' => $author,
             ]);
 
-            if (isset($params['q']) && $params['q'] !== '') {
+            if (!empty($params['q'])) {
                 $params['q'] = trim($params['q']) . ' author:' . $author;
             }
 


### PR DESCRIPTION
The previous implementation would replace everything in `filter`, causing unintended side effects. The implementation in this PR reduces the chance of unintended side effects by merging the nested `filter` array